### PR TITLE
feat: refactor ultraswap api to delegate signing to wallet layer and remove direct private key access

### DIFF
--- a/Sources/JupSwift/Api/JupiterApi/Ultra.swift
+++ b/Sources/JupSwift/Api/JupiterApi/Ultra.swift
@@ -128,4 +128,32 @@ public extension JupiterApi {
         let response = try await execute(signedTransaction: signedTx, requestId: orderResponse.requestId)
         return response
     }
+    
+    /// Performs a token swap using Jupiter's UltraSwap API.
+    ///
+    /// This method:
+    /// 1. Creates a swap order using the provided token mints, amount, and taker address.
+    /// 2. Extracts the base64-encoded transaction from the order response.
+    /// 3. Signs the transaction using the local wallet (via `WalletManager`).
+    /// 4. Executes the signed transaction on-chain and returns the result.
+    ///
+    /// - Parameters:
+    ///   - inputMint: The mint address of the input token (e.g. USDC).
+    ///   - outputMint: The mint address of the output token (e.g. JUP).
+    ///   - amount: The amount of input token to swap, in the smallest unit (e.g. lamports).
+    ///   - taker: (Optional) The wallet address performing the swap. May be required by the API.
+    /// - Throws: An error if order creation, transaction signing, or execution fails.
+    /// - Returns: An `ExecuteResponse` representing the result of the swap.
+    static func ultraSwap(inputMint: String, outputMint: String, amount: String, taker: String?)  async throws -> ExecuteResponse {
+        let orderResponse = try await order(inputMint: inputMint, outputMint: outputMint, amount: amount, taker: taker)
+
+        guard let transaction = orderResponse.transaction else {
+            throw NSError(domain: "No transaction to execute", code: -1)
+        }
+
+        let manager = WalletManager()
+        let signedTx = try await manager.signTransaction(base64Transaction: transaction)
+        let response = try await execute(signedTransaction: signedTx, requestId: orderResponse.requestId)
+        return response
+    }
 }

--- a/Sources/JupSwift/Wallet/WalletModel.swift
+++ b/Sources/JupSwift/Wallet/WalletModel.swift
@@ -39,6 +39,7 @@ public struct PrivateKeyEntry: Codable, Sendable {
 /// - `mnemonics`: Array of stored mnemonic entries.
 /// - `privateKeys`: Array of stored private key entries.
 struct WalletData: Codable {
+    var currentWalletIndex: Int = 0
     var mnemonics: [MnemonicEntry]
     var privateKeys: [PrivateKeyEntry]
 }

--- a/Tests/JupSwiftTests/JupiterApi/UltraTests.swift
+++ b/Tests/JupSwiftTests/JupiterApi/UltraTests.swift
@@ -36,6 +36,14 @@ struct UltraTests {
         print("✅ Order response: \(result)")
     }
     
+    /// Tests the ultraSwap function with given token mints and amount.
+    ///
+    /// ⚠️ To run this test successfully:
+    /// - Replace `taker` with a valid Solana wallet address.
+    /// - Replace `privateKey` with the corresponding private key for that address.
+    /// - Ensure the wallet has a sufficient balance of the input token (e.g., USDC).
+    ///
+    /// This test will fail if any of the above conditions are not met.
     @Test
     func testUltraSwap() async throws {
         let inputMint = "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v" // USDC
@@ -84,5 +92,32 @@ struct UltraTests {
         #expect(!routers.isEmpty, "Routers array should not be empty")
 
         print("✅ Routers: \(routers)")
+    }
+    
+    /// Tests the ultraSwap function with given token mints and amount.
+    ///
+    /// ⚠️ To run this test successfully:
+    /// - Replace `taker` with a valid Solana wallet address.
+    /// - Ensure the wallet has a sufficient balance of the input token (e.g., USDC).
+    ///
+    /// This test will fail if any of the above conditions are not met.
+    @Test
+    func testUltraSwapUsingWallet() async throws {
+        let inputMint = "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v" // USDC
+        let outputMint = "JUPyiwrYJFskUPiHa7hkeR8VUtAeFoSYbKedZNsDvCN" // JUP
+        let amount = "22763399" // minimal（lamports）
+        let taker = "YOUR_SOLANA_ADDRESS_HERE" // replace by address
+
+        do {
+            _ = try await JupiterApi.ultraSwap(
+                inputMint: inputMint,
+                outputMint: outputMint,
+                amount: amount,
+                taker: taker
+            )
+        } catch {
+            print("❌ UltraSwap failed with error: \(error)")
+            throw error
+        }
     }
 }

--- a/Tests/JupSwiftTests/WalletTests/WalletManagerTests.swift
+++ b/Tests/JupSwiftTests/WalletTests/WalletManagerTests.swift
@@ -75,6 +75,21 @@ struct WalletManagerTests {
             
             privateKeyCount = await manager.getPrivateKeysEntry().count
             #expect(privateKeyCount == 5)
+            
+            // check if default address set to index 0 and it's value
+            var address = try await manager.getCurrentAddress()
+            #expect(address == "9pMbqzoZJxSpaMtMJ9zaJqxY75K8esjL43WMTCnNCj1r")
+            
+            // set wallet to index 1 and check it's value
+            try await manager.setCurrentWalletAtIndex(1)
+            address = try await manager.getCurrentAddress()
+            #expect(address == "2Hgf4yX6Xgv9jYisdyKPLpbgLAf8MEE4cuByUv7bYkvX")
+            
+            // sign transaction using current wallet
+            let unsignedTransaction = "Afoj44vDVRXmWN+2b0XJsCMEUgahMabbSNU+vBnJylWI6A2wncgrljIZOZ9sre83TCsurVREk/X5rJSSiq6hxAuAAQAIDC1DU+v8CS6zsH6P1YDxv34gJqfH4duQts70riDegwRWh7Uj+ncbLnnXrncZ0M9fcpfQPh1Y9fJm+wF6ZvdeXAeT62WWp4H7+l5+SX/26TIX4kW9/UIESJwJ9fRHF2a4BeBV0h/1+T5UibrxqsSxFjlJUiOoGJgKrcpTt5U2/pOyAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAACMlyWPTiSJ8bs9ECkUjg2DC1oTmdr/EIQEjnvY2+n4Wawfg/25zlUN6V1VjNx5VGHM9DdKxojsE6mEACIKeNoGAwZGb+UhFzL/7K26csOb57yM5bvF9xJrLEObOkAAAAC0P/on9df2SnTAmx8pWHneSwmrNt/J3VFLMhqns4zl6Mb6evO+2606PWXzaqvJdDGxu+TC0vbg5HymAgNFL11hBHnVW/IxwG7udMVuzmgVB/2xst6j9I5RArHNola8E48G3fbh12Whk9nL4UbO63msHLSF7V9bN5E6jPWFfv8AqQctTjnSwEUMprS9ERx1Vf9YfO/78A64br56TcDYlZ4IBwcABQLAXBUABwAJA/ThBQAAAAAABAIAAwwCAAAA8P4UBgAAAAAKBQMAFQsECZPxe2T0hK52/gUGAAIACQQLAQEKGAsAAwIKCQEIChEUDQADAgwODxALExMSBiPlF8uXeuOtKgEAAAAZZAABAOH1BQAAAABm+LQAAAAAADMAAAsDAwAAAQkB1oUQRIHodQ7RqM53G2HBODrXHK0Mt23syD9oedgHJVAFuL2gvqEFOLs1vBY="
+            let signedTransaction = try await manager.signTransaction(base64Transaction: unsignedTransaction)
+            let correctedSignedTransaction = signTransaction(base64Transaction: unsignedTransaction, privateKey: "5H9zE9jtbsigsKRv5CTTZr8mCRYAyv9246bZFxkkLUyfhb3dDDPCgzR5L443J7oDZQvLSMqmT9mhscHGg1Zfo8xb")
+            #expect(signedTransaction == correctedSignedTransaction)
         } catch {
             print("❌ addMnemonic test failed with error: \(error.localizedDescription)")
         }


### PR DESCRIPTION
## Summary
This PR introduces a more developer-friendly approach to signing transactions by integrating signing capabilities directly into the wallet structure.

## Changes
### Wallet Enhancements:
- Added a currentWalletIndex to the wallet structure to track the currently selected wallet.
- Added methods to retrieve the current wallet's public address and private key based on the index.
- Introduced a method to switch active wallets by index.
- Provided a new wallet-level method to sign transactions using the current wallet.
### UltraSwap API Refactor:
- Removed the need to pass a private key as a parameter.
- Internally uses the wallet’s new signing method to handle transaction signing.
## Why This Is Useful
These changes simplify the integration process for developers using the SDK:
- Once a wallet is created, signing is handled automatically by the SDK.
- Developers no longer need to manually access or manage private keys.
- This reduces potential implementation errors and lowers the barrier to entry for integrating wallet functionality.