### PR TITLE
fix: explicitly mark the necessary properties as public to ensure the…

### DIFF
--- a/Sources/JupSwift/Api/JupiterApi/Model/BalancesResponse.swift
+++ b/Sources/JupSwift/Api/JupiterApi/Model/BalancesResponse.swift
@@ -6,10 +6,10 @@
 //
 
 public struct TokenBalance: Codable, Hashable, Sendable {
-    let amount: String
-    let uiAmount: Double
-    let slot: Int
-    let isFrozen: Bool
+    public let amount: String
+    public let uiAmount: Double
+    public let slot: Int
+    public let isFrozen: Bool
 }
 
 public struct BalancesResponse: Codable, Hashable, Sendable {

--- a/Sources/JupSwift/Api/JupiterApi/Model/ExecuteResponse.swift
+++ b/Sources/JupSwift/Api/JupiterApi/Model/ExecuteResponse.swift
@@ -6,10 +6,10 @@
 //
 
 public struct SwapEvent: Codable, Hashable, Sendable {
-    let inputMint: String
-    let inputAmount: String
-    let outputMint: String
-    let outputAmount: String
+    public let inputMint: String
+    public let inputAmount: String
+    public let outputMint: String
+    public let outputAmount: String
 }
 
 public struct ExecuteResponse: Codable, Hashable, Sendable {
@@ -22,7 +22,7 @@ public struct ExecuteResponse: Codable, Hashable, Sendable {
     public let swapEvents: [SwapEvent]?
 }
 
-struct ExecuteOrderRequest: Encodable {
+internal struct ExecuteOrderRequest: Encodable {
     let signedTransaction: String
     let requestId: String
 }

--- a/Sources/JupSwift/Api/JupiterApi/Model/OrderResponse.swift
+++ b/Sources/JupSwift/Api/JupiterApi/Model/OrderResponse.swift
@@ -6,37 +6,37 @@
 //
 
 public struct RoutePlan: Codable, Hashable, Sendable {
-    let swapInfo: SwapInfo
-    let percent: Int
+    public let swapInfo: SwapInfo
+    public let percent: Int
 }
 
 public struct SwapInfo: Codable, Hashable, Sendable {
-    let ammKey: String
-    let label: String
-    let inputMint: String
-    let outputMint: String
-    let inAmount: String
-    let outAmount: String
-    let feeAmount: String
-    let feeMint: String
+    public let ammKey: String
+    public let label: String
+    public let inputMint: String
+    public let outputMint: String
+    public let inAmount: String
+    public let outAmount: String
+    public let feeAmount: String
+    public let feeMint: String
 }
 
 public struct PlatformFee: Codable, Hashable, Sendable {
-    let amount: String
-    let feeBps: Int
+    public let amount: String
+    public let feeBps: Int
 }
 
 public struct DynamicSlippageReport: Codable, Hashable, Sendable {
-    let amplificationRatio: String?
-    let otherAmount: Int?
-    let simulatedIncurredSlippageBps: Int?
-    let slippageBps: Int
-    let categoryName: String
-    let heuristicMaxSlippageBps: Int
+    public let amplificationRatio: String?
+    public let otherAmount: Int?
+    public let simulatedIncurredSlippageBps: Int?
+    public let slippageBps: Int
+    public let categoryName: String
+    public let heuristicMaxSlippageBps: Int
 }
 
 public struct OrderResponse: Codable, Hashable, Sendable {
-    public let inputMint: String        // require but nullable
+    public let inputMint: String
     public let outputMint: String
     public let inAmount: String
     public let outAmount: String

--- a/Sources/JupSwift/Api/JupiterApi/Model/ShieldResponse.swift
+++ b/Sources/JupSwift/Api/JupiterApi/Model/ShieldResponse.swift
@@ -13,8 +13,4 @@ public struct TokenWarning: Codable, Hashable, Sendable {
 
 public struct ShieldResponse: Codable, Hashable, Sendable {
     public let warnings: [String: [TokenWarning]]
-
-    private enum CodingKeys: String, CodingKey {
-        case warnings
-    }
 }


### PR DESCRIPTION
### Why

-  Some properties in the Ultra API response models are currently not explicitly marked with an access level, which means they default to internal. As a result, they are not accessible to developers who use the SDK externally. This limits the ability to inspect or work with returned data outside the SDK module.

### How

-  Explicitly mark the necessary properties as public to ensure they are accessible to external SDK users.