### PR TITLE
feat: refactor UltraSwap to infer taker address internally

### DIFF
--- a/Sources/JupSwift/Api/JupiterApi/Ultra.swift
+++ b/Sources/JupSwift/Api/JupiterApi/Ultra.swift
@@ -132,26 +132,27 @@ public extension JupiterApi {
     /// Performs a token swap using Jupiter's UltraSwap API.
     ///
     /// This method:
-    /// 1. Creates a swap order using the provided token mints, amount, and taker address.
-    /// 2. Extracts the base64-encoded transaction from the order response.
-    /// 3. Signs the transaction using the local wallet (via `WalletManager`).
-    /// 4. Executes the signed transaction on-chain and returns the result.
+    /// 1. Retrieves the current wallet address (taker) using `WalletManager`.
+    /// 2. Creates a swap order using the provided token mints and amount.
+    /// 3. Extracts the base64-encoded transaction from the order response.
+    /// 4. Signs the transaction using the local wallet.
+    /// 5. Executes the signed transaction on-chain and returns the result.
     ///
     /// - Parameters:
     ///   - inputMint: The mint address of the input token (e.g. USDC).
     ///   - outputMint: The mint address of the output token (e.g. JUP).
     ///   - amount: The amount of input token to swap, in the smallest unit (e.g. lamports).
-    ///   - taker: (Optional) The wallet address performing the swap. May be required by the API.
     /// - Throws: An error if order creation, transaction signing, or execution fails.
     /// - Returns: An `ExecuteResponse` representing the result of the swap.
-    static func ultraSwap(inputMint: String, outputMint: String, amount: String, taker: String?)  async throws -> ExecuteResponse {
+    static func ultraSwap(inputMint: String, outputMint: String, amount: String)  async throws -> ExecuteResponse {
+        let manager = WalletManager()
+        let taker = try await manager.getCurrentAddress()
         let orderResponse = try await order(inputMint: inputMint, outputMint: outputMint, amount: amount, taker: taker)
 
         guard let transaction = orderResponse.transaction else {
             throw NSError(domain: "No transaction to execute", code: -1)
         }
 
-        let manager = WalletManager()
         let signedTx = try await manager.signTransaction(base64Transaction: transaction)
         let response = try await execute(signedTransaction: signedTx, requestId: orderResponse.requestId)
         return response

--- a/Tests/JupSwiftTests/JupiterApi/UltraTests.swift
+++ b/Tests/JupSwiftTests/JupiterApi/UltraTests.swift
@@ -76,7 +76,7 @@ struct UltraTests {
         do {
             let result = try await JupiterApi.shield(mints: mints)
 
-//            #expect(!result.shields.isEmpty, "Shield list should not be empty")
+            #expect(!result.warnings.isEmpty, "Shield list should not be empty")
 
             print("✅ Shield response: \(result)")
         } catch {
@@ -103,17 +103,18 @@ struct UltraTests {
     /// This test will fail if any of the above conditions are not met.
     @Test
     func testUltraSwapUsingWallet() async throws {
+        let manager = WalletManager()
+        try await manager.resetWallet()
+        _ = try await manager.addMnemonic("YOUR_MNEMONIC_HERE")
         let inputMint = "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v" // USDC
         let outputMint = "JUPyiwrYJFskUPiHa7hkeR8VUtAeFoSYbKedZNsDvCN" // JUP
         let amount = "22763399" // minimal（lamports）
-        let taker = "YOUR_SOLANA_ADDRESS_HERE" // replace by address
 
         do {
             _ = try await JupiterApi.ultraSwap(
                 inputMint: inputMint,
                 outputMint: outputMint,
-                amount: amount,
-                taker: taker
+                amount: amount
             )
         } catch {
             print("❌ UltraSwap failed with error: \(error)")


### PR DESCRIPTION
## Summary
This change improves code readability and reduces the potential for errors caused by passing incorrect or unnecessary parameters.
### Why
Previously, the ultraSwap method explicitly required a taker address to be passed in when creating a swap order. However, this address is always derived from the current wallet state, making the external parameter redundant and prone to inconsistency if mismatched. Removing this parameter simplifies the interface and ensures a single source of truth for the taker address.

### How

- Removed the taker parameter from the order(...) function call inside ultraSwap.

- Retrieved the current address internally using WalletManager.getCurrentAddress().

- Updated the method-level documentation to reflect this change, clarifying that the taker address is now automatically resolved.