### PR TITLE
feat: add token API methods for fetching all, new, and tradable tokens

### DIFF
--- a/Sources/JupSwift/Api/JupiterApi/Model/NewTokenListResponse.swift
+++ b/Sources/JupSwift/Api/JupiterApi/Model/NewTokenListResponse.swift
@@ -1,0 +1,34 @@
+//
+//  NewTokenListResponse.swift
+//  JupSwift
+//
+//  Created by Zhao You on 6/6/25.
+//
+
+public typealias NewTokenListResponse = [NewToken]
+
+public struct NewToken: Codable, Hashable, Sendable {
+    public let createdAt: String
+    public let decimals: Int
+    public let freezeAuthority: String?
+    public let knownMarkets: [String]
+    public let logoURI: String?
+    public let metadataUpdatedAt: Int
+    public let mint: String
+    public let mintAuthority: String?
+    public let name: String
+    public let symbol: String
+
+    enum CodingKeys: String, CodingKey {
+        case createdAt = "created_at"
+        case decimals
+        case freezeAuthority = "freeze_authority"
+        case knownMarkets = "known_markets"
+        case logoURI = "logo_uri"
+        case metadataUpdatedAt = "metadata_updated_at"
+        case mint
+        case mintAuthority = "mint_authority"
+        case name
+        case symbol
+    }
+}

--- a/Sources/JupSwift/Api/JupiterApi/Model/TokenInfoResponse.swift
+++ b/Sources/JupSwift/Api/JupiterApi/Model/TokenInfoResponse.swift
@@ -1,0 +1,41 @@
+//
+//  TokenInfoResponse.swift
+//  JupSwift
+//
+//  Created by Zhao You on 6/6/25.
+//
+
+/// The response for a tagged token query, e.g., all 'lst' tokens.
+public typealias TaggedTokenListResponse = [TokenInfoResponse]
+
+public struct TokenInfoResponse: Codable, Hashable, Sendable {
+    public let address: String
+    public let name: String
+    public let symbol: String
+    public let decimals: Int
+    public let logoURI: String?
+    public let tags: [String]?
+    public let dailyVolume: Double?
+    public let createdAt: String
+    public let freezeAuthority: String?
+    public let mintAuthority: String?
+    public let permanentDelegate: String?
+    public let mintedAt: String?
+    public let extensions: [String: String]?
+
+    enum CodingKeys: String, CodingKey {
+        case address
+        case name
+        case symbol
+        case decimals
+        case logoURI
+        case tags
+        case dailyVolume = "daily_volume"
+        case createdAt = "created_at"
+        case freezeAuthority = "freeze_authority"
+        case mintAuthority = "mint_authority"
+        case permanentDelegate = "permanent_delegate"
+        case mintedAt = "minted_at"
+        case extensions
+    }
+}

--- a/Sources/JupSwift/Api/JupiterApi/Token.swift
+++ b/Sources/JupSwift/Api/JupiterApi/Token.swift
@@ -1,0 +1,102 @@
+//
+//  Token.swift
+//  JupSwift
+//
+//  Created by Zhao You on 6/6/25.
+//
+
+import Alamofire
+import Foundation
+
+public extension JupiterApi {
+    
+    /// Fetches token metadata information from the Jupiter Tokens API for a given mint address.
+    ///
+    /// This function configures the Jupiter API in `.lite` mode and targets the `"tokens"` component.
+    /// It then builds a request to fetch the token info from the `"token/{mint}"` endpoint,
+    /// performs the request with a retry policy, and decodes the response into a `TokenInfoResponse` object.
+    ///
+    /// - Parameter mint: The SPL token mint address (as a `String`) for which to fetch metadata.
+    /// - Returns: A `TokenInfoResponse` containing metadata such as name, symbol, decimals, logoURI, etc.
+    /// - Throws: An error if the request fails, the response is invalid, or decoding fails.
+    static func token(mint: String) async throws -> TokenInfoResponse {
+        await JupiterApi.configure(mode: .lite, component: "tokens")
+        let url = await getQuoteURL(endpoint: "token/") + mint
+        let response = try await AF.request(url, interceptor: retryPolicy)
+            .validate()
+            .serializingDecodable(TokenInfoResponse.self)
+            .value
+        return response
+    }
+    
+    /// Fetches the list of token mints for a given liquidity pool market.
+    ///
+    /// - Parameter market: The address of the liquidity pool (market) to query.
+    /// - Returns: An array of token mint addresses associated with the specified liquidity pool.
+    /// - Throws: An error if the network request fails or the response cannot be decoded.
+    static func market(market: String) async throws -> [String] {
+        await JupiterApi.configure(mode: .lite, component: "tokens")
+        let url = await getQuoteURL(endpoint: "market/\(market)/mints")
+        let response = try await AF.request(url, interceptor: retryPolicy)
+            .validate()
+            .serializingDecodable([String].self)
+            .value
+        return response
+    }
+    
+    /// Retrieves a list of all tradable token mint addresses.
+    ///
+    /// - Returns: An array of strings representing the mint addresses of tradable tokens.
+    /// - Throws: An error if the network request fails or the response cannot be decoded.
+    static func tradableTokens() async throws -> [String] {
+        await JupiterApi.configure(mode: .lite, component: "tokens")
+        let url = await getQuoteURL(endpoint: "mints/tradable")
+        let response = try await AF.request(url, interceptor: retryPolicy)
+            .validate()
+            .serializingDecodable([String].self)
+            .value
+        return response
+    }
+    
+    /// Fetches a list of tokens tagged with the given category (e.g., "lst", "stable", etc.).
+    /// - Parameter tag: The tag used to filter tokens (e.g., "lst").
+    /// - Returns: An array of tokens matching the given tag.
+    /// - Throws: An error if the request fails or the response is invalid.
+    static func taggedTokens(for tag: String) async throws -> TaggedTokenListResponse {
+        await JupiterApi.configure(mode: .lite, component: "tokens")
+        let url = await getQuoteURL(endpoint: "tagged/\(tag)")
+        let response = try await AF.request(url, interceptor: retryPolicy)
+            .validate()
+            .serializingDecodable(TaggedTokenListResponse.self)
+            .value
+        return response
+    }
+    
+    /// Fetches the list of newly added tokens.
+    ///
+    /// - Returns: A `NewTokenListResponse` object containing information about the new tokens.
+    /// - Throws: An error if the network request fails or the response cannot be decoded.
+    static func newTokens() async throws -> NewTokenListResponse {
+        await JupiterApi.configure(mode: .lite, component: "tokens")
+        let url = await getQuoteURL(endpoint: "new")
+        let response = try await AF.request(url, interceptor: retryPolicy)
+            .validate()
+            .serializingDecodable(NewTokenListResponse.self)
+            .value
+        return response
+    }
+    
+    /// Retrieves the complete list of all tokens available.
+    ///
+    /// - Returns: An array of `TokenInfoResponse` objects containing detailed information about each token.
+    /// - Throws: An error if the network request fails or the response cannot be decoded.
+    static func allTokens() async throws -> [TokenInfoResponse] {
+        await JupiterApi.configure(mode: .lite, component: "tokens")
+        let url = await getQuoteURL(endpoint: "all")
+        let response = try await AF.request(url, interceptor: retryPolicy)
+            .validate()
+            .serializingDecodable([TokenInfoResponse].self)
+            .value
+        return response
+    }
+}

--- a/Sources/JupSwift/Api/JupiterApi/Ultra.swift
+++ b/Sources/JupSwift/Api/JupiterApi/Ultra.swift
@@ -10,12 +10,6 @@ import Foundation
 
 public extension JupiterApi {
     
-    static var component: String {
-        get {
-            return "ultra"
-        }
-    }
-    
     /// Fetch the balances for a specific account from Jupiter's Ultra API.
     ///
     /// - Parameter account: The Solana wallet address whose balances will be queried.

--- a/Tests/JupSwiftTests/JupiterApi/TokensTests.swift
+++ b/Tests/JupSwiftTests/JupiterApi/TokensTests.swift
@@ -1,0 +1,72 @@
+//
+//  TokensTests.swift
+//  JupSwift
+//
+//  Created by Zhao You on 6/6/25.
+//
+
+import Testing
+@testable import JupSwift
+
+
+struct TokensTests {
+    @Test
+    func testToken() async throws {
+        let token = "JUPyiwrYJFskUPiHa7hkeR8VUtAeFoSYbKedZNsDvCN"
+        
+        // call Jupiter API
+        let result = try await JupiterApi.token(mint: token)
+        
+        #expect(result.symbol == "JUP", "Expected symbol to be JUP")
+        #expect(result.decimals == 6, "Expected decimals to be 6")
+        
+        print("✅ Token response: \(result)")
+    }
+    
+    @Test
+    func testMarket() async throws {
+        let market = "BVRbyLjjfSBcoyiYFuxbgKYnWuiFaF9CSXEa5vdSZ9Hh"
+        
+        // call Jupiter API
+        let result = try await JupiterApi.market(market: market)
+        
+        #expect(result.count == 2, "Expected length to be 2")
+        #expect(result.contains("So11111111111111111111111111111111111111112"), "Expected result to contain wrapped SOL")
+        #expect(result.contains("EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v"), "Expected result to contain USDC")
+        
+        print("✅ Market response: \(result)")
+    }
+    
+    @Test
+    func testTradable() async throws {
+        // call Jupiter API
+        let result = try await JupiterApi.tradableTokens()
+        
+        #expect(result.count > 8888, "Expected length to be greater than 8888")
+    }
+    
+    @Test
+    func testTaggedTokens() async throws {
+        // call Jupiter API
+        let tag = "lst"
+        let result = try await JupiterApi.taggedTokens(for: tag)
+        
+        #expect(result.count > 10, "Expected length to be greater than 10")
+    }
+    
+    @Test
+    func testNewTokens() async throws {
+        // call Jupiter API
+        let result = try await JupiterApi.newTokens()
+        
+        #expect(result.count > 8888, "Expected length to be greater than 8888")
+    }
+    
+    @Test
+    func testAllTokens() async throws {
+        // call Jupiter API
+        let result = try await JupiterApi.allTokens()
+        
+        #expect(result.count > 8888, "Expected length to be greater than 8888")
+    }
+}

--- a/Tests/JupSwiftTests/JupiterApi/UltraTests.swift
+++ b/Tests/JupSwiftTests/JupiterApi/UltraTests.swift
@@ -14,7 +14,7 @@ struct UltraTests {
     func testBalancesWithValidAccount() async throws {
         let account = "ULNw3m7kxvPP8RHXAwYRTW5yQos7RWB4nmVBsiCix6V"
 
-        // 呼叫 Jupiter API
+        // call Jupiter API
         let result = try await JupiterApi.balances(account: account)
         
         #expect(result.balances.count > 0, "Expected balances to be non-empty")


### PR DESCRIPTION
# 🚀 Release: JupSwift 1.0.0 – Token API Integration

## Why

We’re preparing the first stable release of `JupSwift` (`v1.0.0`) to provide a lightweight and reliable Swift client for interacting with the Jupiter Aggregator. This release focuses on supporting token-related and ultra routing queries, which are essential for building performant, token-aware DEX interfaces and wallet applications on Solana.

- The token API enables clients to fetch tradable tokens, full token lists, new tokens, and liquidity pool compositions.

- The ultra API prepares the groundwork for advanced routing and quoting features, enabling high-precision simulations and trades.

## How

This PR introduces and finalizes the tokens API module with the following async functions:

- `allTokens()` – Fetches full token list (`GET /all`)

- `newTokens()` – Fetches newly listed tokens (`GET /new`)

- `tradableTokens()` – Fetches tradable tokens (`GET /mints/tradable`)

- `market(market:)` – Fetches token mints in a specific liquidity pool (`GET /market/:market/mints`)

Additional changes:

- Integrated API configuration using `.lite` mode

- Applied consistent decoding logic with `Alamofire` and retry policy

- Added corresponding response models (`TokenInfoResponse`, `NewTokenListResponse`)