### PR TITLE
feat: add support for Jupiter Trigger API integration (create, execute, cancel, query)

### DIFF
--- a/Sources/JupSwift/Api/JupiterApi/Model/CancelOrderResponse.swift
+++ b/Sources/JupSwift/Api/JupiterApi/Model/CancelOrderResponse.swift
@@ -1,0 +1,26 @@
+//
+//  CancelOrderResponse.swift
+//  JupSwift
+//
+//  Created by Zhao You on 11/6/25.
+//
+
+public struct CancelOrderResponse: Codable, Hashable, Sendable {
+    public let requestId: String
+    public let transaction: String
+}
+
+public struct CancelOrdersResponse: Codable, Hashable, Sendable {
+    public let requestId: String
+    public let transactions: [String]
+}
+
+internal struct CancelOrder: Encodable {
+    let maker: String
+    let order: String
+}
+
+internal struct CancelOrders: Encodable {
+    let maker: String
+    let orders: [String]
+}

--- a/Sources/JupSwift/Api/JupiterApi/Model/CreateTriggerOrderResponse.swift
+++ b/Sources/JupSwift/Api/JupiterApi/Model/CreateTriggerOrderResponse.swift
@@ -1,0 +1,27 @@
+//
+//  CreateTriggerOrderResponse.swift
+//  JupSwift
+//
+//  Created by Zhao You on 9/6/25.
+//
+
+public struct CreateTriggerOrderResponse: Codable, Hashable, Sendable {
+    public let requestId: String
+    public let transaction: String
+    public let order: String?
+}
+
+internal struct CreateTriggerOrderRequest: Encodable {
+    let inputMint: String
+    let outputMint: String
+    let maker: String
+    let payer: String
+    let params: TriggerParams
+    var feeAccount: String?
+}
+
+internal struct TriggerParams: Encodable {
+    let makingAmount: String
+    let takingAmount: String
+    let feeBps: String = "50"
+}

--- a/Sources/JupSwift/Api/JupiterApi/Model/GetTriggerOrdersResponse.swift
+++ b/Sources/JupSwift/Api/JupiterApi/Model/GetTriggerOrdersResponse.swift
@@ -1,0 +1,61 @@
+//
+//  GetTriggerOrdersResponse.swift
+//  JupSwift
+//
+//  Created by Zhao You on 11/6/25.
+//
+
+import Foundation
+
+public struct GetTriggerOrdersResponse: Codable, Hashable, Sendable {
+    public let user: String
+    public let orderStatus: String
+    public let orders: [Order]
+    public let totalPages: Int
+    public let page: Int
+    public let totalItems: Int?
+}
+
+public struct Order: Codable, Hashable, Sendable {
+    public let userPubkey: String
+    public let orderKey: String
+    public let inputMint: String
+    public let outputMint: String
+    public let makingAmount: String
+    public let takingAmount: String
+    public let remainingMakingAmount: String
+    public let remainingTakingAmount: String
+    public let rawMakingAmount: String
+    public let rawTakingAmount: String
+    public let rawRemainingMakingAmount: String
+    public let rawRemainingTakingAmount: String
+    public let slippageBps: String
+    public let slTakingAmount: String?
+    public let rawSlTakingAmount: String?
+    public let expiredAt: String?
+    public let createdAt: String
+    public let updatedAt: String
+    public  let status: String
+    public let openTx: String
+    public let closeTx: String
+    public let programVersion: String
+    public let trades: [Trade]
+}
+
+public struct Trade: Codable, Hashable, Sendable {
+    public let orderKey: String
+    public let keeper: String
+    public let inputMint: String
+    public let outputMint: String
+    public let inputAmount: String
+    public let outputAmount: String
+    public let rawInputAmount: String
+    public let rawOutputAmount: String
+    public let feeMint: String
+    public let feeAmount: String
+    public let rawFeeAmount: String
+    public let txId: String
+    public let confirmedAt: String
+    public let action: String
+    public let productMeta: String?
+}

--- a/Sources/JupSwift/Api/JupiterApi/Model/TriggerExecuteResponse.swift
+++ b/Sources/JupSwift/Api/JupiterApi/Model/TriggerExecuteResponse.swift
@@ -1,0 +1,17 @@
+//
+//  TriggerExecuteResponse.swift
+//  JupSwift
+//
+//  Created by Zhao You on 10/6/25.
+//
+
+public struct TriggerExecuteResponse: Codable, Hashable, Sendable {
+    public let code: Int
+    public let signature: String
+    public let status: String
+}
+
+internal struct TriggerExecuteRequest: Encodable {
+    let requestId: String
+    let signedTransaction: String
+}

--- a/Sources/JupSwift/Api/JupiterApi/Trigger.swift
+++ b/Sources/JupSwift/Api/JupiterApi/Trigger.swift
@@ -1,0 +1,149 @@
+//
+//  Trigger.swift
+//  JupSwift
+//
+//  Created by Zhao You on 8/6/25.
+//
+
+import Alamofire
+import Foundation
+
+public extension JupiterApi {
+    
+    /// Creates a trigger order via Jupiter API.
+    ///
+    /// - Parameters:
+    ///   - inputMint: The mint address of the input token.
+    ///   - outputMint: The mint address of the output token.
+    ///   - makingAmount: The amount of the input token to provide.
+    ///   - takingAmount: The minimum amount of output token to receive.
+    ///   - payer: The wallet address paying for the transaction.
+    /// - Returns: A `CreateTriggerOrderResponse` containing the order details.
+    static func createOrder(inputMint: String, outputMint: String, makingAmount: String, takingAmount: String, payer: String) async throws -> CreateTriggerOrderResponse {
+        await JupiterApi.configure(mode: .lite, component: "trigger")
+        let url = await getQuoteURL(endpoint: "/createOrder")
+        let params: TriggerParams = TriggerParams(makingAmount: makingAmount, takingAmount: takingAmount)
+        var requestBody = CreateTriggerOrderRequest(inputMint: inputMint, outputMint: outputMint, maker: payer, payer: payer, params: params)
+        if (outputMint == "So11111111111111111111111111111111111111112") {
+            requestBody.feeAccount = "3ssPtzEQc42w5zRMjNZSroQ36cToxUGx5AjD3HZCku9N"
+        } else if (outputMint == "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v") {
+            requestBody.feeAccount = "Afkk6kwhiGtRnKwYEJY1XbSG4J8oedB5CXW4zrPy6MLV"
+        } else if (outputMint == "JUPyiwrYJFskUPiHa7hkeR8VUtAeFoSYbKedZNsDvCN") {
+            requestBody.feeAccount = "4eNzPMjH2Xw5ggXGLeRbZNgxTdDD5KxqKrFAxMJQ5hya"
+        }
+        
+        let headers = await getHeaders()
+
+        let response = try await AF.request(url,
+                                            method: .post,
+                                            parameters: requestBody,
+                                            encoder: JSONParameterEncoder.default,
+                                            headers: headers,
+                                            interceptor: retryPolicy)
+            .validate()
+            .serializingDecodable(CreateTriggerOrderResponse.self)
+            .value
+        return response
+    }
+    
+    /// Executes a signed trigger transaction using the Jupiter API.
+    ///
+    /// - Parameters:
+    ///   - requestId: The ID returned from the createOrder call, used to link the transaction.
+    ///   - signedTransaction: The base64-encoded signed transaction to be executed.
+    /// - Returns: A `TriggerExecuteResponse` containing the execution result.
+    static func triggerExecute(requestId: String, signedTransaction: String) async throws -> TriggerExecuteResponse {
+        await JupiterApi.configure(mode: .lite, component: "trigger")
+        let url = await getQuoteURL(endpoint: "/execute")
+        let requestBody = TriggerExecuteRequest(requestId: requestId, signedTransaction: signedTransaction)
+        
+        let headers = await getHeaders()
+
+        let response = try await AF.request(url,
+                                            method: .post,
+                                            parameters: requestBody,
+                                            encoder: JSONParameterEncoder.default,
+                                            headers: headers,
+                                            interceptor: retryPolicy)
+            .validate()
+            .serializingDecodable(TriggerExecuteResponse.self)
+            .value
+        return response
+    }
+    
+    /// Cancels a trigger order via the Jupiter API.
+    ///
+    /// - Parameters:
+    ///   - maker: The wallet address that created the order.
+    ///   - order: The unique order ID to be cancelled.
+    /// - Returns: A `CancelOrderResponse` containing the result of the cancellation.
+    static func cancelTriggerOrder(maker: String, order: String) async throws -> CancelOrderResponse {
+        await JupiterApi.configure(mode: .lite, component: "trigger")
+        let url = await getQuoteURL(endpoint: "/cancelOrder")
+        let requestBody = CancelOrder(maker: maker, order: order)
+        
+        let headers = await getHeaders()
+
+        let response = try await AF.request(url,
+                                            method: .post,
+                                            parameters: requestBody,
+                                            encoder: JSONParameterEncoder.default,
+                                            headers: headers,
+                                            interceptor: retryPolicy)
+            .validate()
+            .serializingDecodable(CancelOrderResponse.self)
+            .value
+        return response
+    }
+    
+    /// Cancels multiple trigger orders via the Jupiter API.
+    ///
+    /// - Parameters:
+    ///   - maker: The wallet address that created the orders.
+    ///   - orders: An array of order IDs to be cancelled.
+    /// - Returns: A `CancelOrdersResponse` containing the result of the batch cancellation.
+    static func cancelTriggerOrders(maker: String, orders: [String]) async throws -> CancelOrdersResponse {
+        await JupiterApi.configure(mode: .lite, component: "trigger")
+        let url = await getQuoteURL(endpoint: "/cancelOrder")
+        let requestBody = CancelOrders(maker: maker, orders: orders)
+        
+        let headers = await getHeaders()
+
+        let response = try await AF.request(url,
+                                            method: .post,
+                                            parameters: requestBody,
+                                            encoder: JSONParameterEncoder.default,
+                                            headers: headers,
+                                            interceptor: retryPolicy)
+            .validate()
+            .serializingDecodable(CancelOrdersResponse.self)
+            .value
+        return response
+    }
+    
+    /// Retrieves all active trigger orders for a specific user.
+    ///
+    /// - Parameter user: The wallet address of the user.
+    /// - Returns: A `GetTriggerOrdersResponse` containing all active orders for the user.
+    static func getActiveTriggerOrders(user: String) async throws -> GetTriggerOrdersResponse {
+        return try await getTriggerOrders(user: user, orderStatus: "active")
+    }
+    
+    /// Retrieves all historical (executed or cancelled) trigger orders for a specific user.
+    ///
+    /// - Parameter user: The wallet address of the user.
+    /// - Returns: A `GetTriggerOrdersResponse` containing the user's order history.
+    static func getHistoryTriggerOrders(user: String) async throws -> GetTriggerOrdersResponse {
+        return try await getTriggerOrders(user: user, orderStatus: "history")
+    }
+    
+    static func getTriggerOrders(user: String, orderStatus: String) async throws -> GetTriggerOrdersResponse {
+        await JupiterApi.configure(mode: .lite, component: "trigger")
+        let url = await getQuoteURL(endpoint: "/getTriggerOrders?user=\(user)&orderStatus=\(orderStatus)")
+        let response = try await AF.request(url, interceptor: retryPolicy)
+            .validate()
+            .serializingDecodable(GetTriggerOrdersResponse.self)
+            .value
+        return response
+    }
+}

--- a/Tests/JupSwiftTests/JupiterApi/TriggerTests.swift
+++ b/Tests/JupSwiftTests/JupiterApi/TriggerTests.swift
@@ -1,0 +1,72 @@
+//
+//  TriggerTests.swift
+//  JupSwift
+//
+//  Created by Zhao You on 9/6/25.
+//
+
+import Testing
+@testable import JupSwift
+
+struct TriggerTests {
+    
+    @Test
+    func testCreateOrderAndExecute() async throws {
+        let privateKey = "{YOUR_PRIVATE_KEY}"
+        let inputMint = "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v"
+        let outputMint = "JUPyiwrYJFskUPiHa7hkeR8VUtAeFoSYbKedZNsDvCN"
+        // call Jupiter API
+        let result = try await JupiterApi.createOrder(inputMint: inputMint, outputMint: outputMint, makingAmount: "90000000", takingAmount: "200000000", payer: "{YOUR ADDRESS}")
+        print("✅ CreateOrder response: \(result)")
+        let signedTransaction = signTransaction(base64Transaction: result.transaction, privateKey: privateKey)
+        
+        let executeResult = try await JupiterApi.triggerExecute(requestId: result.requestId, signedTransaction: signedTransaction)
+        print("✅ Execute response: \(executeResult)")
+    }
+    
+    @Test
+    func testCancelOrder() async throws {
+        let privateKey = "{YOUR_PRIVATE_KEY}"
+        let maker = "{YOUR ADDRESS}"
+        let order = "{YOUR ORDERS}"
+        let result = try await JupiterApi.cancelTriggerOrder(maker: maker, order: order)
+        print("✅ CancelOrder response: \(result)")
+        let signedTransaction = signTransaction(base64Transaction: result.transaction, privateKey: privateKey)
+        
+        let executeResult = try await JupiterApi.triggerExecute(requestId: result.requestId, signedTransaction: signedTransaction)
+        print("✅ Execute response: \(executeResult)")
+    }
+    
+    @Test
+    func testCancelOrders() async throws {
+        let privateKey = "{YOUR_PRIVATE_KEY}"
+        let maker = "{YOUR_ADDRESS}"
+        let orders = ["", ""] // your orders
+        let result = try await JupiterApi.cancelTriggerOrders(maker: maker, orders: orders)
+        print("✅ CancelOrder response: \(result)")
+        for base64Transaction in result.transactions {
+            do {
+                let signedTransaction = signTransaction(base64Transaction: base64Transaction, privateKey: privateKey)
+                
+                let executeResult = try await JupiterApi.triggerExecute(
+                    requestId: result.requestId,
+                    signedTransaction: signedTransaction
+                )
+                
+                print("✅ Execute response: \(executeResult)")
+            } catch {
+                print("❌ Failed to execute transaction: \(error)")
+            }
+        }
+    }
+    
+    @Test
+    func testGetActiveTriggerOrders() async throws {
+        let user = "{YOUR_ADDRESS}"
+        let result = try await JupiterApi.getActiveTriggerOrders(user: user)
+        print(result)
+        
+        let historyResult = try await JupiterApi.getHistoryTriggerOrders(user: user)
+        print(historyResult)
+    }
+}


### PR DESCRIPTION
## Why

We need to support Jupiter's Trigger API to enable automated, condition-based trading. This feature allows users to:

- Create limit/trigger orders

- Execute signed transactions once conditions are met

- Cancel orders individually or in batch

- Fetch current active and historical orders

Adding this integration enables advanced trading flows in the wallet/dApp and is essential for strategies like TWAP orders.

## How

This PR introduces the following additions:

1. Create Trigger Order

- `createOrder(...)`: Sends trigger order creation requests based on specified input/output mints and amounts.

- Dynamically assigns `feeAccount` based on the `outputMint`.

2. Execute Trigger Order

- `triggerExecute(...)`: Submits a signed base64 transaction to execute a pending trigger order by `requestId`.

3. Cancel Trigger Orders

- `cancelTriggerOrder(...)`: Cancels a specific trigger order.

- `cancelTriggerOrders(...)`: Cancels multiple trigger orders in a single request.

4. Query Orders

- `getActiveTriggerOrders(...)`: Retrieves all active orders for a user.

- `getHistoryTriggerOrders(...)`: Retrieves all historical orders (executed or cancelled).

5. Shared Improvements

- All requests use the shared `getQuoteURL` and `getHeaders`.

- Consistent configuration using `JupiterApi.configure(mode: .lite, component: "trigger")`.

- Added proper response decoding and error validation via Alamofire.