### PR TITLE
feat: Add full support for Recurring API integration

### DIFF
--- a/Sources/JupSwift/Api/JupiterApi/JupiterApi.swift
+++ b/Sources/JupSwift/Api/JupiterApi/JupiterApi.swift
@@ -24,4 +24,20 @@ public enum JupiterApi {
     public static func getHeaders() async -> HTTPHeaders {
         return await JupiterApiConfig.shared.getHeaders()
     }
+    
+    static func debugLogRequest(_ request: DataRequest) {
+    #if DEBUG
+        request.cURLDescription { description in
+            print("📤 cURL Request:\n\(description)")
+        }
+
+        request.responseString { response in
+            if let body = response.value {
+                print("📥 Raw Response:\n\(body)")
+            } else {
+                print("📥 No response body")
+            }
+        }
+    #endif
+    }
 }

--- a/Sources/JupSwift/Api/JupiterApi/Model/CancelOrderResponse.swift
+++ b/Sources/JupSwift/Api/JupiterApi/Model/CancelOrderResponse.swift
@@ -5,12 +5,7 @@
 //  Created by Zhao You on 11/6/25.
 //
 
-public struct CancelOrderResponse: Codable, Hashable, Sendable {
-    public let requestId: String
-    public let transaction: String
-}
-
-public struct CancelOrdersResponse: Codable, Hashable, Sendable {
+public struct CancelTriggerOrdersResponse: Codable, Hashable, Sendable {
     public let requestId: String
     public let transactions: [String]
 }

--- a/Sources/JupSwift/Api/JupiterApi/Model/CreateRecurringOrderResponse.swift
+++ b/Sources/JupSwift/Api/JupiterApi/Model/CreateRecurringOrderResponse.swift
@@ -1,0 +1,94 @@
+//
+//  CreateRecurringOrderResponse.swift
+//  JupSwift
+//
+//  Created by Zhao You on 14/6/25.
+//
+
+import Foundation
+
+public struct CreateRecurringOrderRequest: Encodable, Sendable {
+    let user: String
+    let inputMint: String
+    let outputMint: String
+    let params: RecurringParams
+}
+
+public enum RecurringParams: Encodable, Sendable {
+    case time(TimeParams)
+    case price(PriceParams)
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+
+        switch self {
+        case .time(let value):
+            try container.encode(value, forKey: .time)
+        case .price(let value):
+            try container.encode(value, forKey: .price)
+        }
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case time
+        case price
+    }
+}
+
+public struct TimeParams: Encodable, Sendable {
+    let inAmount: UInt64
+    let interval: UInt64
+    var maxPrice: Double? = nil
+    var minPrice: Double? = nil
+    let numberOfOrders: UInt64
+    var startAt: UInt64? = nil
+    
+    public init(
+            inAmount: UInt64,
+            interval: UInt64,
+            maxPrice: Double? = nil,
+            minPrice: Double? = nil,
+            numberOfOrders: UInt64,
+            startAt: UInt64? = nil
+        ) {
+            self.inAmount = inAmount
+            self.interval = interval
+            self.maxPrice = maxPrice
+            self.minPrice = minPrice
+            self.numberOfOrders = numberOfOrders
+            self.startAt = startAt
+        }
+}
+
+public struct PriceParams: Encodable, Sendable {
+    let depositAmount: UInt64
+    let incrementUsdcValue: UInt64
+    let interval: UInt64
+    var startAt: UInt64? = nil
+    
+    public init(depositAmount: UInt64, incrementUsdcValue: UInt64, interval: UInt64, startAt: UInt64? = nil) {
+        self.depositAmount = depositAmount
+        self.incrementUsdcValue = incrementUsdcValue
+        self.interval = interval
+        self.startAt = startAt
+    }
+}
+
+public struct CancelRecurringOrderRequest: Encodable, Sendable {
+    let order: String
+    let user: String
+    let recurringType: String
+}
+
+public struct PriceDepositeRequest: Encodable, Sendable {
+    let order: String
+    let user: String
+    let amount: UInt64
+}
+
+public struct PriceWithdrawRequest: Encodable, Sendable {
+    let order: String
+    let user: String
+    let inputOrOutput: String = "In"
+    let amount: UInt64
+}

--- a/Sources/JupSwift/Api/JupiterApi/Model/ExecuteResponse.swift
+++ b/Sources/JupSwift/Api/JupiterApi/Model/ExecuteResponse.swift
@@ -5,6 +5,18 @@
 //  Created by Zhao You on 25/5/25.
 //
 
+
+public typealias CancelTriggerOrderResponse = RequestTransactionResponse
+public typealias CreateRecurringOrderResponse = RequestTransactionResponse
+public typealias CancelRecurringOrderResponse = RequestTransactionResponse
+public typealias PriceDepositeResponse = RequestTransactionResponse
+public typealias PriceWithdrawResponse = RequestTransactionResponse
+
+public struct RequestTransactionResponse: Codable, Hashable, Sendable {
+    public let requestId: String
+    public let transaction: String
+}
+
 public struct SwapEvent: Codable, Hashable, Sendable {
     public let inputMint: String
     public let inputAmount: String

--- a/Sources/JupSwift/Api/JupiterApi/Model/GetRecurringOrdersResponse.swift
+++ b/Sources/JupSwift/Api/JupiterApi/Model/GetRecurringOrdersResponse.swift
@@ -1,0 +1,59 @@
+//
+//  GetRecurringOrdersResponse.swift
+//  JupSwift
+//
+//  Created by Zhao You on 14/6/25.
+//
+
+import Foundation
+
+public struct GetRecurringOrdersResponse: Codable, Sendable {
+    public let user: String
+    public let orderStatus: OrderStatus
+    public let all: [RecurringOrder]
+    public let totalPages: Int
+    public let totalItems: Int
+    public let page: Int
+}
+
+public enum OrderStatus: String, Codable, Sendable {
+    case active
+    case history
+}
+
+public enum RecurringType: String, Codable {
+    case time
+    case price
+    case all
+}
+
+public struct RecurringOrder: Codable, Sendable {
+    public let recurringType: String
+    public let userPubkey: String
+    public let orderKey: String
+    public let inputMint: String
+    public let outputMint: String
+    public let inDeposited: String
+    public let inWithdrawn: String
+    public let rawInDeposited: String
+    public let rawInWithdrawn: String
+    public let cycleFrequency: String
+    public let outWithdrawn: String
+    public let inAmountPerCycle: String
+    public let minOutAmount: String
+    public let maxOutAmount: String
+    public let inUsed: String
+    public let outReceived: String
+    public let rawOutWithdrawn: String
+    public let rawInAmountPerCycle: String
+    public let rawMinOutAmount: String
+    public let rawMaxOutAmount: String
+    public let rawInUsed: String
+    public let rawOutReceived: String
+    public let openTx: String
+    public let closeTx: String
+    public let userClosed: Bool
+    public let createdAt: String
+    public let updatedAt: String
+    public let trades: [Trade]
+}

--- a/Sources/JupSwift/Api/JupiterApi/Model/RecurringExecuteResponse.swift
+++ b/Sources/JupSwift/Api/JupiterApi/Model/RecurringExecuteResponse.swift
@@ -1,0 +1,18 @@
+//
+//  RecurringExecuteResponse.swift
+//  JupSwift
+//
+//  Created by Zhao You on 14/6/25.
+//
+
+public struct RecurringExecuteResponse: Codable, Hashable, Sendable {
+    public let signature: String
+    public let status: String
+    public let order: String?
+    public let error: String?
+}
+
+internal struct RecurringExecuteRequest: Encodable {
+    let requestId: String
+    let signedTransaction: String
+}

--- a/Sources/JupSwift/Api/JupiterApi/Recurring.swift
+++ b/Sources/JupSwift/Api/JupiterApi/Recurring.swift
@@ -29,15 +29,20 @@ public extension JupiterApi {
         
         let headers = await getHeaders()
         
-        let response = try await AF.request(url,
-                                            method: .post,
-                                            parameters: requestBody,
-                                            encoder: JSONParameterEncoder.default,
-                                            headers: headers,
-                                            interceptor: retryPolicy)
+        let dataRequest = AF.request(url,
+                                     method: .post,
+                                     parameters: requestBody,
+                                     encoder: JSONParameterEncoder.default,
+                                     headers: headers,
+                                     interceptor: retryPolicy)
+        
+        debugLogRequest(dataRequest)
+        
+        let response = try await dataRequest
             .validate()
             .serializingDecodable(CreateRecurringOrderResponse.self)
             .value
+        
         return response
     }
     
@@ -58,16 +63,19 @@ public extension JupiterApi {
         let requestBody = RecurringExecuteRequest(requestId: requestId, signedTransaction: signedTransaction)
         
         let headers = await getHeaders()
-
-        let response = try await AF.request(url,
-                                            method: .post,
-                                            parameters: requestBody,
-                                            encoder: JSONParameterEncoder.default,
-                                            headers: headers,
-                                            interceptor: retryPolicy)
+        let dataRequest = AF.request(url,
+                                     method: .post,
+                                     parameters: requestBody,
+                                     encoder: JSONParameterEncoder.default,
+                                     headers: headers,
+                                     interceptor: retryPolicy)
+        debugLogRequest(dataRequest)
+        
+        let response = try await dataRequest
             .validate()
             .serializingDecodable(RecurringExecuteResponse.self)
             .value
+        
         return response
     }
     
@@ -90,6 +98,7 @@ public extension JupiterApi {
             .validate()
             .serializingDecodable(GetRecurringOrdersResponse.self)
             .value
+        
         return response
     }
     
@@ -112,15 +121,20 @@ public extension JupiterApi {
         
         let headers = await getHeaders()
 
-        let response = try await AF.request(url,
-                                            method: .post,
-                                            parameters: requestBody,
-                                            encoder: JSONParameterEncoder.default,
-                                            headers: headers,
-                                            interceptor: retryPolicy)
+        let dataRequest = AF.request(url,
+                                     method: .post,
+                                     parameters: requestBody,
+                                     encoder: JSONParameterEncoder.default,
+                                     headers: headers,
+                                     interceptor: retryPolicy)
+        
+        debugLogRequest(dataRequest)
+        
+        let response = try await dataRequest
             .validate()
             .serializingDecodable(CancelRecurringOrderResponse.self)
             .value
+        
         return response
     }
     
@@ -144,12 +158,16 @@ public extension JupiterApi {
         
         let headers = await getHeaders()
 
-        let response = try await AF.request(url,
-                                            method: .post,
-                                            parameters: requestBody,
-                                            encoder: JSONParameterEncoder.default,
-                                            headers: headers,
-                                            interceptor: retryPolicy)
+        let dataRequest = AF.request(url,
+                                     method: .post,
+                                     parameters: requestBody,
+                                     encoder: JSONParameterEncoder.default,
+                                     headers: headers,
+                                     interceptor: retryPolicy)
+        
+        debugLogRequest(dataRequest)
+        
+        let response = try await dataRequest
             .validate()
             .serializingDecodable(PriceDepositeResponse.self)
             .value
@@ -176,31 +194,19 @@ public extension JupiterApi {
         
         let headers = await getHeaders()
 
-        let response = try await AF.request(url,
-                                            method: .post,
-                                            parameters: requestBody,
-                                            encoder: JSONParameterEncoder.default,
-                                            headers: headers,
-                                            interceptor: retryPolicy)
+        let dataRequest = AF.request(url,
+                                     method: .post,
+                                     parameters: requestBody,
+                                     encoder: JSONParameterEncoder.default,
+                                     headers: headers,
+                                     interceptor: retryPolicy)
+        
+        debugLogRequest(dataRequest)
+        
+        let response = try await dataRequest
             .validate()
             .serializingDecodable(PriceWithdrawResponse.self)
             .value
-        
-//        let dataRequest = AF.request(url,
-//                                     method: .post,
-//                                     parameters: requestBody,
-//                                     encoder: JSONParameterEncoder.default,
-//                                     headers: headers,
-//                                     interceptor: retryPolicy)
-//        
-//        dataRequest.cURLDescription { description in
-//            print("📤 cURL Request:\n\(description)")
-//        }
-//        
-//        let response = try await dataRequest
-//            .validate()
-//            .serializingDecodable(PriceWithdrawResponse.self)
-//            .value
         
         return response
     }

--- a/Sources/JupSwift/Api/JupiterApi/Recurring.swift
+++ b/Sources/JupSwift/Api/JupiterApi/Recurring.swift
@@ -1,0 +1,207 @@
+//
+//  Recurring.swift
+//  JupSwift
+//
+//  Created by Zhao You on 14/6/25.
+//
+
+import Alamofire
+import Foundation
+
+public extension JupiterApi {
+    /// Creates a recurring order using the Jupiter Lite API.
+    ///
+    /// This function sends a POST request to the `/createOrder` endpoint
+    /// with the given mints, user public key, and recurring order parameters.
+    ///
+    /// - Parameters:
+    ///   - inputMint: The mint address of the input token (e.g., USDC).
+    ///   - outputMint: The mint address of the output token (e.g., SOL).
+    ///   - params: The recurring order parameters (either time-based or price-based).
+    ///   - user: The user's public key string.
+    ///
+    /// - Returns: A `CreateRecurringOrderResponse` containing order details from the API.
+    /// - Throws: An error if the request fails or the response cannot be decoded.
+    static func createRecurringOrder(inputMint: String, outputMint: String, params: RecurringParams, user: String) async throws -> CreateRecurringOrderResponse {
+        await JupiterApi.configure(mode: .lite, component: "recurring")
+        let url = await getQuoteURL(endpoint: "/createOrder")
+        let requestBody = CreateRecurringOrderRequest(user: user, inputMint: inputMint, outputMint: outputMint, params: params)
+        
+        let headers = await getHeaders()
+        
+        let response = try await AF.request(url,
+                                            method: .post,
+                                            parameters: requestBody,
+                                            encoder: JSONParameterEncoder.default,
+                                            headers: headers,
+                                            interceptor: retryPolicy)
+            .validate()
+            .serializingDecodable(CreateRecurringOrderResponse.self)
+            .value
+        return response
+    }
+    
+    /// Executes a signed recurring order transaction via the Jupiter Lite API.
+    ///
+    /// This function submits a signed transaction for a recurring order execution
+    /// to the `/execute` endpoint, using the provided request ID.
+    ///
+    /// - Parameters:
+    ///   - requestId: The unique identifier for the recurring order execution request.
+    ///   - signedTransaction: The base64-encoded signed transaction string.
+    ///
+    /// - Returns: A `RecurringExecuteResponse` with the result of the execution.
+    /// - Throws: An error if the network request fails or the response cannot be parsed.
+    static func recurringExecute(requestId: String, signedTransaction: String) async throws -> RecurringExecuteResponse {
+        await JupiterApi.configure(mode: .lite, component: "recurring")
+        let url = await getQuoteURL(endpoint: "/execute")
+        let requestBody = RecurringExecuteRequest(requestId: requestId, signedTransaction: signedTransaction)
+        
+        let headers = await getHeaders()
+
+        let response = try await AF.request(url,
+                                            method: .post,
+                                            parameters: requestBody,
+                                            encoder: JSONParameterEncoder.default,
+                                            headers: headers,
+                                            interceptor: retryPolicy)
+            .validate()
+            .serializingDecodable(RecurringExecuteResponse.self)
+            .value
+        return response
+    }
+    
+    /// Fetches recurring orders for a given user account from the Jupiter Lite API.
+    ///
+    /// This function queries the `/getRecurringOrders` endpoint with the user's public key,
+    /// filtered by order status and recurring type (time-based or price-based).
+    ///
+    /// - Parameters:
+    ///   - account: The public key of the user whose recurring orders you want to fetch.
+    ///   - orderStatus: The status of the orders to fetch (e.g., `.active`, `.history`).
+    ///   - recurringType: The type of recurring order (e.g., `.time`, `.price`).
+    ///
+    /// - Returns: A `GetRecurringOrdersResponse` containing a list of matching recurring orders.
+    /// - Throws: An error if the request fails or the response cannot be decoded.
+    static func getRecurringOrders(account: String, orderStatus: OrderStatus, recurringType: RecurringType) async throws -> GetRecurringOrdersResponse {
+        await JupiterApi.configure(mode: .lite, component: "recurring")
+        let url = await getQuoteURL(endpoint: "/getRecurringOrders?user=\(account)&orderStatus=\(orderStatus)&recurringType=\(recurringType)&includeFailedTx=true")
+        let response = try await AF.request(url, interceptor: retryPolicy)
+            .validate()
+            .serializingDecodable(GetRecurringOrdersResponse.self)
+            .value
+        return response
+    }
+    
+    /// Cancels an existing recurring order using the Jupiter Lite API.
+    ///
+    /// This function sends a POST request to the `/cancelOrder` endpoint to cancel a specific recurring order.
+    /// It requires the order ID, user public key, and the recurring type (e.g., "time" or "price").
+    ///
+    /// - Parameters:
+    ///   - order: The order key (ID) of the recurring order to cancel.
+    ///   - user: The public key of the user who owns the order.
+    ///   - recurringType: The type of the recurring order ("time" or "price").
+    ///
+    /// - Returns: A `CancelRecurringOrderResponse` indicating the result of the cancellation.
+    /// - Throws: An error if the request fails or the response cannot be decoded.
+    static func cancelRecurringOrder(order: String, user: String, recurringType: String) async throws -> CancelRecurringOrderResponse {
+        await JupiterApi.configure(mode: .lite, component: "recurring")
+        let url = await getQuoteURL(endpoint: "/cancelOrder")
+        let requestBody = CancelRecurringOrderRequest(order: order, user: user, recurringType: recurringType)
+        
+        let headers = await getHeaders()
+
+        let response = try await AF.request(url,
+                                            method: .post,
+                                            parameters: requestBody,
+                                            encoder: JSONParameterEncoder.default,
+                                            headers: headers,
+                                            interceptor: retryPolicy)
+            .validate()
+            .serializingDecodable(CancelRecurringOrderResponse.self)
+            .value
+        return response
+    }
+    
+    /// Deposits additional funds into an existing price-based recurring order.
+    ///
+    /// This function sends a POST request to the `/priceDeposit` endpoint to increase the total deposit
+    /// for a price-based recurring order. This is useful when the upcoming orders require more funds
+    /// than originally provided.
+    ///
+    /// - Parameters:
+    ///   - order: The order key (ID) of the recurring order to deposit into.
+    ///   - user: The public key of the user who owns the order.
+    ///   - amount: The amount to deposit, in base units (e.g., 6 decimals for USDC means 50 USDC = 50_000_000).
+    ///
+    /// - Returns: A `PriceDepositeResponse` confirming the deposit was processed.
+    /// - Throws: An error if the request fails or the response cannot be decoded.
+    static func priceDeposit(order: String, user: String, amount: UInt64) async throws -> PriceDepositeResponse {
+        await JupiterApi.configure(mode: .lite, component: "recurring")
+        let url = await getQuoteURL(endpoint: "/priceDeposit")
+        let requestBody = PriceDepositeRequest(order: order, user: user, amount: amount)
+        
+        let headers = await getHeaders()
+
+        let response = try await AF.request(url,
+                                            method: .post,
+                                            parameters: requestBody,
+                                            encoder: JSONParameterEncoder.default,
+                                            headers: headers,
+                                            interceptor: retryPolicy)
+            .validate()
+            .serializingDecodable(PriceDepositeResponse.self)
+            .value
+        
+        return response
+    }
+    
+    /// Withdraws unused funds from a price-based recurring order on Jupiter.
+    ///
+    /// Sends a POST request to the `/priceWithdraw` endpoint to withdraw USDC that was previously
+    /// deposited into a recurring order but not yet used in executed trades.
+    ///
+    /// - Parameters:
+    ///   - order: The unique identifier (order key) of the recurring order.
+    ///   - user: The user's public key (wallet address) who owns the order.
+    ///   - amount: The amount to withdraw, in base units (e.g., 1 USDC = 1_000_000).
+    ///
+    /// - Returns: A `PriceWithdrawResponse` object containing the result of the withdrawal.
+    /// - Throws: An error if the request fails or the response cannot be decoded.
+    static func priceWithdraw(order: String, user: String, amount: UInt64) async throws -> PriceWithdrawResponse {
+        await JupiterApi.configure(mode: .lite, component: "recurring")
+        let url = await getQuoteURL(endpoint: "/priceWithdraw")
+        let requestBody = PriceWithdrawRequest(order: order, user: user, amount: amount)
+        
+        let headers = await getHeaders()
+
+        let response = try await AF.request(url,
+                                            method: .post,
+                                            parameters: requestBody,
+                                            encoder: JSONParameterEncoder.default,
+                                            headers: headers,
+                                            interceptor: retryPolicy)
+            .validate()
+            .serializingDecodable(PriceWithdrawResponse.self)
+            .value
+        
+//        let dataRequest = AF.request(url,
+//                                     method: .post,
+//                                     parameters: requestBody,
+//                                     encoder: JSONParameterEncoder.default,
+//                                     headers: headers,
+//                                     interceptor: retryPolicy)
+//        
+//        dataRequest.cURLDescription { description in
+//            print("📤 cURL Request:\n\(description)")
+//        }
+//        
+//        let response = try await dataRequest
+//            .validate()
+//            .serializingDecodable(PriceWithdrawResponse.self)
+//            .value
+        
+        return response
+    }
+}

--- a/Sources/JupSwift/Api/JupiterApi/Trigger.swift
+++ b/Sources/JupSwift/Api/JupiterApi/Trigger.swift
@@ -76,8 +76,8 @@ public extension JupiterApi {
     /// - Parameters:
     ///   - maker: The wallet address that created the order.
     ///   - order: The unique order ID to be cancelled.
-    /// - Returns: A `CancelOrderResponse` containing the result of the cancellation.
-    static func cancelTriggerOrder(maker: String, order: String) async throws -> CancelOrderResponse {
+    /// - Returns: A `CancelTriggerOrderResponse` containing the result of the cancellation.
+    static func cancelTriggerOrder(maker: String, order: String) async throws -> CancelTriggerOrderResponse {
         await JupiterApi.configure(mode: .lite, component: "trigger")
         let url = await getQuoteURL(endpoint: "/cancelOrder")
         let requestBody = CancelOrder(maker: maker, order: order)
@@ -91,7 +91,7 @@ public extension JupiterApi {
                                             headers: headers,
                                             interceptor: retryPolicy)
             .validate()
-            .serializingDecodable(CancelOrderResponse.self)
+            .serializingDecodable(CancelTriggerOrderResponse.self)
             .value
         return response
     }
@@ -101,8 +101,8 @@ public extension JupiterApi {
     /// - Parameters:
     ///   - maker: The wallet address that created the orders.
     ///   - orders: An array of order IDs to be cancelled.
-    /// - Returns: A `CancelOrdersResponse` containing the result of the batch cancellation.
-    static func cancelTriggerOrders(maker: String, orders: [String]) async throws -> CancelOrdersResponse {
+    /// - Returns: A `CancelTriggerOrdersResponse` containing the result of the batch cancellation.
+    static func cancelTriggerOrders(maker: String, orders: [String]) async throws -> CancelTriggerOrdersResponse {
         await JupiterApi.configure(mode: .lite, component: "trigger")
         let url = await getQuoteURL(endpoint: "/cancelOrder")
         let requestBody = CancelOrders(maker: maker, orders: orders)
@@ -116,7 +116,7 @@ public extension JupiterApi {
                                             headers: headers,
                                             interceptor: retryPolicy)
             .validate()
-            .serializingDecodable(CancelOrdersResponse.self)
+            .serializingDecodable(CancelTriggerOrdersResponse.self)
             .value
         return response
     }

--- a/Tests/JupSwiftTests/JupiterApi/RecurringTests.swift
+++ b/Tests/JupSwiftTests/JupiterApi/RecurringTests.swift
@@ -31,7 +31,7 @@ struct RecurringTests {
         let inputMint = "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v"
         let outputMint = "So11111111111111111111111111111111111111112"
         // call Jupiter API
-        let priceParams = PriceParams(depositAmount: 50000000, incrementUsdcValue: 10000000, interval: 86400)
+        let priceParams = PriceParams(depositAmount: 100000000, incrementUsdcValue: 10000000, interval: 86400)
         let result = try await JupiterApi.createRecurringOrder(inputMint: inputMint, outputMint: outputMint, params: .price(priceParams), user: "{YOUR_ADDRESS}")
         print("✅ CreateOrder response: \(result)")
         

--- a/Tests/JupSwiftTests/JupiterApi/RecurringTests.swift
+++ b/Tests/JupSwiftTests/JupiterApi/RecurringTests.swift
@@ -1,0 +1,66 @@
+//
+//  RecurringTests.swift
+//  JupSwift
+//
+//  Created by Zhao You on 14/6/25.
+//
+
+import Testing
+@testable import JupSwift
+
+struct RecurringTests {
+    
+    @Test
+    func testCreateRecurringOrderByTimeAndExecute() async throws {
+        let privateKey = "{YOUR_PRIVATE_KEY}"
+        let inputMint = "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v"
+        let outputMint = "So11111111111111111111111111111111111111112"
+        // call Jupiter API
+        let timeParams = TimeParams(inAmount: 100000000, interval: 86400, numberOfOrders: 2)
+        let result = try await JupiterApi.createRecurringOrder(inputMint: inputMint, outputMint: outputMint, params: .time(timeParams), user: "{YOUR_ADDRESS}")
+        print("✅ CreateOrder response: \(result)")
+        
+        let signedTransaction = signTransaction(base64Transaction: result.transaction, privateKey: privateKey)
+        let executeResult = try await JupiterApi.recurringExecute(requestId: result.requestId, signedTransaction: signedTransaction)
+        print("✅ Execute response: \(executeResult)")
+    }
+    
+    @Test
+    func testCreateRecurringOrderByPriceAndExecute() async throws {
+        let privateKey = "{YOUR_PRIVATE_KEY}"
+        let inputMint = "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v"
+        let outputMint = "So11111111111111111111111111111111111111112"
+        // call Jupiter API
+        let priceParams = PriceParams(depositAmount: 50000000, incrementUsdcValue: 10000000, interval: 86400)
+        let result = try await JupiterApi.createRecurringOrder(inputMint: inputMint, outputMint: outputMint, params: .price(priceParams), user: "{YOUR_ADDRESS}")
+        print("✅ CreateOrder response: \(result)")
+        
+        let signedTransaction = signTransaction(base64Transaction: result.transaction, privateKey: privateKey)
+        let executeResult = try await JupiterApi.recurringExecute(requestId: result.requestId, signedTransaction: signedTransaction)
+        print("✅ Execute response: \(executeResult)")
+    }
+    
+    @Test
+    func testGetRecurringOrders() async throws {
+        let result = try await JupiterApi.getRecurringOrders(account: "{YOUR_ADDRESS}", orderStatus: .history, recurringType: .all)
+        print("✅ GetRecurringOrders response: \(result)")
+    }
+    
+    @Test
+    func testCancelkRecurringOrder() async throws {
+        let result = try await JupiterApi.cancelRecurringOrder(order: "{ORDER_FROM_GET_RECURRING_ORDERS_RESPONSE}", user: "{YOUR_ADDRESS}", recurringType: "time")
+        print("cancel RecurringOrder response: \(result)")
+    }
+    
+    @Test
+    func testPriceDeposit() async throws {
+        let result = try await JupiterApi.priceDeposit(order: "{ORDER_FROM_GET_RECURRING_ORDERS_RESPONSE}", user: "{YOUR_ADDRESS}", amount: 60000000)
+        print("PriceDeposit response: \(result)")
+    }
+    
+    @Test
+    func testPriceWithdraw() async throws {
+        let result = try await JupiterApi.priceWithdraw(order: "{ORDER_FROM_GET_RECURRING_ORDERS_RESPONSE}", user: "{YOUR_ADDRESS}", amount: 60000000)
+        print("PriceWithdraw response: \(result)")
+    }
+}


### PR DESCRIPTION
# 🔁 feat: Add full support for Recurring API integration

## Why
To enable automated, scheduled trading on Jupiter, we integrated support for the Recurring API. This includes features for both time-based and price-based recurring orders, allowing users to create, cancel, execute, deposit, and withdraw funds over time. This is critical for use cases like DCA (Dollar-Cost Averaging) or reactive trading based on price thresholds, directly from our SDK.

## How
This PR implements the full set of Recurring API endpoints under the JupiterApi namespace, including:

### ✅ Core Features Implemented

- `createRecurringOrder(...)`: Create a new recurring order for either time or price type.

- `cancelRecurringOrder(...)`: Cancel an existing order.

- `recurringExecute(...)`: Submit a signed transaction to fulfill a recurring order.

- `getRecurringOrders(...)`: Fetch user's active or historical recurring orders.

- `priceDeposit(...)`: Deposit additional funds into a price-based order.

- `priceWithdraw(...)`: Withdraw remaining funds from a price-based order.

### 🧱 Supporting Models

- `TimeParams` and `PriceParams` structs

- `RecurringParams` enum (to support either type)

- Strongly typed response models for each endpoint

- Enums for `OrderStatus`, `RecurringType` to improve type safety

- URL parameter formatting and header helpers

### 🐛 Debug Support

- Debug logging (cURL + raw response) added behind `#if DEBUG` for easier issue diagnosis during development.

Notes

- All endpoints are routed using the `recurring` component of the Jupiter API.

- Error responses and status code validation are handled using Alamofire's `.validate()` and `.serializingDecodable(...)`.

- Public structs marked `Sendable` and properly initialized to avoid access level issues.